### PR TITLE
Downgrade project to version 0.1.0 (pre 1)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ inThisBuild(List(
 
 name := "spark-persistent-homology"
 
-version := "1.0.0-SNAPSHOT"
+version := "0.1.0-SNAPSHOT"
 
 scalaVersion := "2.12.14"
 

--- a/examples/random-points-cloud/build.sbt
+++ b/examples/random-points-cloud/build.sbt
@@ -8,5 +8,5 @@ lazy val root = (project in file("."))
   )
 
 libraryDependencies += "org.apache.spark" %% "spark-core" % "3.1.1" % "provided"
-libraryDependencies += "io.github.jakipatryk" %% "spark-persistent-homology" % "1.0.0-SNAPSHOT"
+libraryDependencies += "io.github.jakipatryk" %% "spark-persistent-homology" % "0.1.0-SNAPSHOT"
 libraryDependencies += "com.github.scopt" %% "scopt" % "4.0.1"


### PR DESCRIPTION
I don't have enough free time to have efficient, highly optimized for Vietoris-Rips persistent homology v1.0.0 release anytime soon, that's why I decided to go with version 0.1.0 and follow Early-SemVer versioning for the future.